### PR TITLE
[PSQLADM-164]: Installed proxysql-admin.cnf.in in /usr/share/proxysql…

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,6 +1,6 @@
 proxysql /usr/bin/
 etc/proxysql.cnf /etc/
-etc/proxysql-admin.cnf /etc/
+etc/proxysql-admin.cnf.in /usr/share/proxysql/etc/
 etc/config.toml /etc/
 etc/init.d/proxysql /etc/init.d/
 proxysql_galera_writer /usr/bin/

--- a/debian/postinst
+++ b/debian/postinst
@@ -15,7 +15,8 @@ case "$1" in
             chmod 0640 /etc/proxysql.cnf
         fi
 
-        if [ -f /etc/proxysql-admin.cnf ]; then
+        if [ ! -f /etc/proxysql-admin.cnf ]; then
+            cp /usr/share/proxysql/etc/proxysql-admin.cnf.in /etc/proxysql-admin.cnf
             chmod 0640 /etc/proxysql-admin.cnf
             chown root:proxysql /etc/proxysql-admin.cnf
         fi
@@ -126,3 +127,10 @@ case "$1" in
     exit 1
     ;;
 esac
+
+EXISTING_FILE_PROPERTIES_COUNT=$(grep "export .*=" /etc/proxysql-admin.cnf | awk -F '[ =]' '{print $2}' | sort -u | wc -l)
+NEW_FILE_PROPERTIES_COUNT=$(grep "export .*=" /usr/share/proxysql/etc/proxysql-admin.cnf.in | awk -F '[ =]' '{print $2}' | sort -u | wc -l)
+
+if [ "$EXISTING_FILE_PROPERTIES_COUNT" -ne "$NEW_FILE_PROPERTIES_COUNT" ]; then
+    echo "NOTE: /usr/share/proxysql/etc/proxysql-admin.cnf.in does not match the configuration of existing /etc/proxysql-admin.cnf. Please review the two files and ensure that the configuration in /etc/proxysql-admin.cnf is updated accordingly."
+fi

--- a/debian/postrm
+++ b/debian/postrm
@@ -42,6 +42,7 @@ if [ "$1" = "purge" ]; then
   if [ "$RET" = "true" ]; then
     rm -rf /var/lib/proxysql
     rm -rf /var/run/proxysql
+    rm -f /etc/proxysql-admin.cnf
     userdel proxysql || true
   fi
   db_fset proxysql/postrm_remove_data seen false

--- a/debian/rules
+++ b/debian/rules
@@ -63,7 +63,7 @@ override_dh_auto_install:
 	mkdir -p $(TMP)/var/lib/proxysql
 	cp src/proxysql $(TMP)/
 	cp etc/proxysql.cnf $(TMP)/etc/
-	cp etc/proxysql-admin.cnf $(TMP)/etc/
+	cp etc/proxysql-admin.cnf $(TMP)/etc/proxysql-admin.cnf.in
 	cp etc/config.toml $(TMP)/etc/
 	cp etc/init.d/proxysql $(TMP)/etc/init.d
 	cp tools/proxysql_galera_checker.sh $(TMP)/proxysql_galera_checker
@@ -73,7 +73,7 @@ override_dh_auto_install:
 	cp tools/proxysql-status $(TMP)/proxysql-status
 	cp tools/proxysql-admin-common $(TMP)/proxysql-admin-common
 	cp tools/proxysql-common $(TMP)/proxysql-common
-	cp tools/proxysql-login-files $(TMP)/proxysql-login-file
+	cp tools/proxysql-login-file $(TMP)/proxysql-login-file
 	cp tools/pxc_scheduler_handler $(TMP)/pxc_scheduler_handler
 	cp tools/percona-scheduler-admin $(TMP)/percona-scheduler-admin
 

--- a/debian/rules.systemd
+++ b/debian/rules.systemd
@@ -63,7 +63,7 @@ override_dh_auto_install:
 	mkdir -p $(TMP)/var/lib/proxysql
 	cp src/proxysql $(TMP)/
 	cp etc/proxysql.cnf $(TMP)/etc/
-	cp etc/proxysql-admin.cnf $(TMP)/etc/
+	cp etc/proxysql-admin.cnf $(TMP)/etc/proxysql-admin.cnf.in
 	cp etc/config.toml $(TMP)/etc/
 	cp etc/init.d/proxysql $(TMP)/etc/init.d
 	cp tools/proxysql_galera_checker.sh $(TMP)/proxysql_galera_checker
@@ -74,6 +74,6 @@ override_dh_auto_install:
 	cp debian/proxysql.service $(TMP)/proxysql.service
 	cp tools/proxysql-admin-common $(TMP)/proxysql-admin-common
 	cp tools/proxysql-common $(TMP)/proxysql-common
-	cp tools/proxysql-login-files $(TMP)/proxysql-login-file
+	cp tools/proxysql-login-file $(TMP)/proxysql-login-file
 	cp tools/pxc_scheduler_handler $(TMP)/pxc_scheduler_handler
 	cp tools/percona-scheduler-admin $(TMP)/percona-scheduler-admin

--- a/debian/rules.xenial
+++ b/debian/rules.xenial
@@ -60,7 +60,7 @@ override_dh_auto_install:
 	mkdir -p $(TMP)/var/lib/proxysql
 	cp src/proxysql $(TMP)/
 	cp etc/proxysql.cnf $(TMP)/etc/
-	cp etc/proxysql-admin.cnf $(TMP)/etc/
+	cp etc/proxysql-admin.cnf $(TMP)/etc/proxysql-admin.cnf.in
 	cp etc/config.toml $(TMP)/etc/
 	cp etc/init.d/proxysql $(TMP)/etc/init.d
 	cp tools/proxysql_galera_checker.sh $(TMP)/proxysql_galera_checker
@@ -72,6 +72,6 @@ override_dh_auto_install:
 	cp debian/proxysql.service $(TMP)/proxysql.service
 	cp tools/proxysql-admin-common $(TMP)/proxysql-admin-common
 	cp tools/proxysql-common $(TMP)/proxysql-common
-	cp tools/proxysql-login-files $(TMP)/proxysql-login-file
+	cp tools/proxysql-login-file $(TMP)/proxysql-login-file
 	cp tools/pxc_scheduler_handler $(TMP)/pxc_scheduler_handler
 	cp tools/percona-scheduler-admin $(TMP)/percona-scheduler-admin

--- a/scripts/proxysql_builder.sh
+++ b/scripts/proxysql_builder.sh
@@ -116,9 +116,6 @@ get_sources(){
     git clone ${GIT_REPO}
     cd proxysql-packaging
     git checkout ${GIT_BRANCH}
-    sed -i 's/proxysql-login-files/proxysql-login-file/' debian/rules
-    sed -i 's/proxysql-login-files/proxysql-login-file/' debian/rules.systemd
-    sed -i 's/proxysql-login-files/proxysql-login-file/' debian/rules.xenial || true
     cd ../
     git clone ${PAT_REPO}
     cd proxysql-admin-tool


### PR DESCRIPTION
- The change now installs proxysql-admin.cnf.in file in /usr/share/proxysql/etc and then checks if proxysql-admin.cnf does not exist in /etc then it creates it.
- If it already exists, then it checks if property is added or removed in new file, if yes then throws a message asking user to make the new changes in /etc/proxysql-admin.cnf
- In RPM, added missing dependency package
- In debian, updated rules files to remove sed statements making same changes from proxysql_builder.sh