### PR TITLE
PSQLADM-518: Add systemd unit for proxysql --inital

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -14,3 +14,4 @@ pxc_scheduler_handler /usr/bin/
 percona-scheduler-admin /usr/bin/
 proxysql-logrotate /etc/logrotate.d/
 proxysql.service /lib/systemd/system/
+proxysql-initial.service /lib/systemd/system/

--- a/debian/proxysql-initial.service
+++ b/debian/proxysql-initial.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=High Performance Advanced Proxy for MySQL, this service will reset the database and start ProxySQL
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/systemctl set-environment PROXYSQL_OPTS="--initial"
+ExecStart=/bin/systemctl start proxysql
+ExecStartPost=/bin/systemctl unset-environment PROXYSQL_OPTS
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/rules.systemd
+++ b/debian/rules.systemd
@@ -72,6 +72,7 @@ override_dh_auto_install:
 	cp tools/proxysql-logrotate $(TMP)/proxysql-logrotate
 	cp tools/proxysql-status $(TMP)/proxysql-status
 	cp debian/proxysql.service $(TMP)/proxysql.service
+	cp debian/proxysql-initial.service $(TMP)/proxysql-initial.service
 	cp tools/proxysql-admin-common $(TMP)/proxysql-admin-common
 	cp tools/proxysql-common $(TMP)/proxysql-common
 	cp tools/proxysql-login-file $(TMP)/proxysql-login-file

--- a/rpm/proxysql.spec
+++ b/rpm/proxysql.spec
@@ -71,6 +71,7 @@ install -m 0640 %SOURCE3 %{buildroot}/%{_sysconfdir}
 %if 0%{?systemd}
   install -m 0755 -d %{buildroot}/%{_unitdir}
   install -m 0644 systemd/system/proxysql.service %{buildroot}/%{_unitdir}/proxysql.service
+  install -m 0644 systemd/system/proxysql-initial.service %{buildroot}/%{_unitdir}/proxysql-initial.service
 %else
   install -m 0755 -d %{buildroot}/etc/rc.d/init.d
   install -m 0755 etc/init.d/proxysql %{buildroot}/%{_sysconfdir}/init.d
@@ -178,6 +179,7 @@ exit 0
 %{_bindir}/proxysql
 %if 0%{?systemd}
 %{_unitdir}/proxysql.service
+%{_unitdir}/proxysql-initial.service
 %else
 %{_sysconfdir}/init.d/proxysql
 %endif


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PSQLADM-518

***
https://github.com/sysown/proxysql/issues/2334

A new unit file is introduced namely proxysql-initial which will pass the --initial switch to the systemd environment and then start the regular proxysql service.

This aligns us with upstream's proxysql-initial service.